### PR TITLE
specify JAX version

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ typical install time ≈ 10 minutes.
 
 first install jax (with GPU support)
 
-``` pip install "jax[cuda]" -f https://storage.googleapis.com/jax-releases/jax_cuda_releases.html ```
+``` pip install "jax[cuda]==0.7" -f https://storage.googleapis.com/jax-releases/jax_cuda_releases.html ```
 
 second install colabdesign
 


### PR DESCRIPTION
Hi,

The current README installation steps lead to the following error message: 
```
TypeError: ShapedArray.__init__() got an unexpected keyword argument 'named_shape'
```
It is caused by deprecating the 'named_shape' argument in the [latest versions of JAX](https://www.gitclear.com/open_repos/google/jax/release/jax-v0.4.34).

Specifying `jax[cuda]==0.7` fixes the issue.